### PR TITLE
PASE-1455 | Bugfix: Switch `Http` mock from final class extension to local instance + misc 6.1+ compatibility.

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+wp-tests-config.php

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ version: "3.5"
 services:
 
   pipeline-test:
-    image: penskemediacorporation/pipeline-test:php8.0-wp6.1
+    image: penskemediacorporation/pipeline-test:php8.0-wp6.2
     env_file: docker-compose.env
     restart: on-failure
     command: start-pipeline-build-test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ version: "3.5"
 services:
 
   pipeline-test:
-    image: penskemediacorporation/pipeline-test:php8
+    image: penskemediacorporation/pipeline-test:php8.0-wp6.1
     env_file: docker-compose.env
     restart: on-failure
     command: start-pipeline-build-test

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,22 +1,17 @@
-<phpunit
-        bootstrap="tests/bootstrap.php"
-        backupGlobals="false"
-        colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
->
-    <testsuites>
-        <testsuite name="test">
-            <directory prefix="test-" suffix=".php">./tests/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true" />
-    </logging>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" backupGlobals="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <report>
+      <text outputFile="php://stdout" showUncoveredFiles="true"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="test">
+      <directory prefix="test-" suffix=".php">./tests/</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/src/classes/bootstrap.php
+++ b/src/classes/bootstrap.php
@@ -595,6 +595,11 @@ class Bootstrap {
 			class_alias( 'PMC\Unit_Test\Traits\Singleton', 'PMC\Global_Functions\Traits\Singleton' );
 		}
 
+		// Point deprecated \Requests class (pre-6.2) over to new one.
+		if ( ! class_exists( 'WpOrg\Requests\Requests', false ) ) {
+			class_alias( 'Requests', 'WpOrg\Requests\Requests' );
+		}
+
 		// Remove these action to prevent header already send errors.
 		remove_all_actions( 'clear_auth_cookie' );
 		remove_all_actions( 'jetpack_sso_handle_login' );

--- a/src/classes/bootstrap.php
+++ b/src/classes/bootstrap.php
@@ -192,11 +192,12 @@ class Bootstrap {
 	/**
 	 * Filter to ignore deprecated function warnings/errors
 	 *
-	 * @param string $function Deprecated function that is caught.
+	 * @param string $function     Deprecated function that is caught.
+	 * @param string $description  The description of the error.
 	 *
 	 * @return bool|string
 	 */
-	function pmc_deprecated_function( $function ) {
+	function pmc_deprecated_function( $function, $description = '' ) {
 
 		// Allow list of the deprecates function to prevent unit test errors.
 		$allowed_list = [
@@ -309,7 +310,7 @@ class Bootstrap {
 		];
 
 		foreach ( $allowed_patterns as $pattern ) {
-			if ( preg_match( '/' . $pattern . '/', $function ) ) {
+			if ( preg_match( '/' . $pattern . '/', $function ) || preg_match( '/' . $pattern . '/', $description ) ) {
 				return false; // Ignore the deprecated warning/error messages.
 			}
 		}
@@ -321,11 +322,12 @@ class Bootstrap {
 	/**
 	 * Passes PMC code to the list of `_doing_it_wrong()` calls.
 	 *
-	 * @param string $function The function to add.
+	 * @param string $function     The function to add.
+	 * @param string $description  The description of the error.
 	 *
 	 * @return string $function The function to add.
 	 */
-	public function pmc_doing_it_wrong( $function ) {
+	public function pmc_doing_it_wrong( $function, $description = '' ) {
 
 		// Allowed list of the deprecated functions to prevent unit test errors.
 		$allowed_list = [
@@ -354,10 +356,12 @@ class Bootstrap {
 
 		$allowed_patterns = [
 			'was called too early and so it will not work properly',
+			'Conditional query tags do not work before the query is run',
+			'wpcom_vip_load_plugin',
 		];
 
 		foreach ( $allowed_patterns as $pattern ) {
-			if ( preg_match( '/' . $pattern . '/', $function ) ) {
+			if ( preg_match( '/' . $pattern . '/', $function ) || preg_match( '/' . $pattern . '/', $description ) ) {
 				return false; // Ignore the deprecated warning/error messages.
 			}
 		}

--- a/src/classes/bootstrap.php
+++ b/src/classes/bootstrap.php
@@ -128,7 +128,7 @@ class Bootstrap {
 		// Using unit test bootstrap function to add filter, the wp core has not loaded yet at this point.
 		tests_add_filter( 'muplugins_loaded', [ $this, 'muplugins_loaded_late_bind' ], self::LOW_PRIORITY );
 		tests_add_filter( 'muplugins_loaded', [ $this, 'muplugins_loaded_early_bind' ], self::HIGH_PRIORITY );
-		tests_add_filter( 'setup_theme', [ $this, 'load_pmc_required_plugins' ], self::HIGH_PRIORITY );
+		tests_add_filter( 'muplugins_loaded', [ $this, 'load_pmc_required_plugins' ], self::HIGH_PRIORITY );
 		tests_add_filter( 'after_setup_theme', [ $this, 'after_setup_theme_early_bind' ], self::HIGH_PRIORITY );
 		tests_add_filter( 'after_setup_theme', [ $this, 'after_setup_theme_late_bind' ], self::LOW_PRIORITY );
 		tests_add_filter( 'pmc_do_not_load_plugin', [ $this, 'pmc_do_not_load_plugin' ], self::DEFAULT_PRIORITY, 4 );

--- a/src/mocks/http.php
+++ b/src/mocks/http.php
@@ -23,7 +23,7 @@ class Http implements \PMC\Unit_Test\Interfaces\Mocker {
 	/**
 	 * Curl request handler
 	 *
-	 * @var \WpOrg\Requests\Transport\Curl|Requests_Transport_cURL
+	 * @var \WpOrg\Requests\Transport\Curl|\Requests_Transport_cURL
 	 */
 	protected $_curl;
 
@@ -48,7 +48,7 @@ class Http implements \PMC\Unit_Test\Interfaces\Mocker {
 	public function __construct() {
 		$this->_curl = class_exists( '\WpOrg\Requests\Transport\Curl' )
 			? new \WpOrg\Requests\Transport\Curl()
-			: new Requests_Transport_cURL();
+			: new \Requests_Transport_cURL();
 	}
 
 	public function provide_service() {

--- a/src/mocks/http.php
+++ b/src/mocks/http.php
@@ -351,7 +351,7 @@ class Http implements \PMC\Unit_Test\Interfaces\Mocker {
 	 */
 	public function action_wp_feed_options( SimplePie &$feed, $url ) {
 		if ( ! empty( $url ) ) {
-			$result = \Requests::get( $url );
+			$result = \WpOrg\Requests\Requests::get( $url );
 			$feed->set_raw_data( $result->body );
 			$feed->file          = null;
 			$feed->feed_url      = null;

--- a/src/mocks/http.php
+++ b/src/mocks/http.php
@@ -276,7 +276,7 @@ class Http implements \PMC\Unit_Test\Interfaces\Mocker {
 
 					// magic key word for passthrough and retrieve from the remote server
 					if ( '__remote_get' === $response_body ) {
-						$result = self::$_curl->request( $url, $headers, $data, $options );
+						$result = $this->_curl->request( $url, $headers, $data, $options );
 						return apply_filters( self::FILTER_REMOTE_GET, $result, $url, $headers, $data, $options );
 					}
 
@@ -323,7 +323,7 @@ class Http implements \PMC\Unit_Test\Interfaces\Mocker {
 			return sprintf( "HTTP/1.1 404 Not Found\r\n\r\nRequest not mocked: %s", $url );
 		}
 
-		$result = self::$_curl->request( $url, $headers, $data, $options );
+		$result = $this->_curl->request( $url, $headers, $data, $options );
 		return apply_filters( self::FILTER_REMOTE_GET, $result, $url, $headers, $data, $options );
 
 	}

--- a/src/mocks/http.php
+++ b/src/mocks/http.php
@@ -57,16 +57,26 @@ class Http implements \PMC\Unit_Test\Interfaces\Mocker {
 
 	/**
 	 * Helper function to intercept the transports class
+	 *
+	 * Note: In WordPress < 6.2 environments, \WpOrg\Requests\Requests is aliased to \Requests.
+	 *
 	 * @return [type] [description]
 	 */
 	public function intercept_transport() {
 		if ( empty( static::$_transports_stored ) ) {
-			static::$_transports_stored = \PMC\Unit_Test\Utility::get_hidden_static_property( 'Requests', 'transports' );
+			static::$_transports_stored = \PMC\Unit_Test\Utility::get_hidden_static_property(
+				'WpOrg\Requests\Requests', 'transports'
+			);
+
 			// force the transport to use this transport class
-			\PMC\Unit_Test\Utility::set_and_get_hidden_static_property( 'Requests', 'transports', [ self::class ] );
+			\PMC\Unit_Test\Utility::set_and_get_hidden_static_property(
+				'WpOrg\Requests\Requests',
+				'transports',
+				[ self::class ]
+			);
 
 			// Reset the caching entry to force a new transport to initialize and lookup
-			\PMC\Unit_Test\Utility::set_and_get_hidden_static_property( 'Requests', 'transport', [] );
+			\PMC\Unit_Test\Utility::set_and_get_hidden_static_property( 'WpOrg\Requests\Requests', 'transport', [] );
 
 			add_action( 'wp_feed_options', [ $this, 'action_wp_feed_options' ], self::ACTION_PRIORITY, 2 );
 		}

--- a/src/mocks/http.php
+++ b/src/mocks/http.php
@@ -329,18 +329,93 @@ class Http implements \PMC\Unit_Test\Interfaces\Mocker {
 	}
 
 	/**
+	 * Send multiple HTTP requests simultaneously
+	 *
+	 * @param  array $options   Global options, see {@see \WpOrg\Requests\Requests::response()} for documentation.
+	 * @param  array $requests  Request data (array of 'url', 'headers', 'data', 'options') as per {@see \WpOrg\Requests\Transport::request()}.
+	 * @return array            Array of \WpOrg\Requests\Response objects (may contain \WpOrg\Requests\Exception or string responses as well).
+	 *
+	 * @codeCoverageIgnore  This is just a wrapper for a class that's only available in WordPress 6.2+ environments.
+	 */
+	public function request_multiple( $requests, $options ) {
+		return $this->_curl->request_multiple( $requests, $options );
+	}
+
+	/**
 	 * Test HTTP request
 	 *
 	 * This is just a wrapper for \WpOrg\Requests\Transport\Curl::test().
 	 *
 	 * @param  array<string,bool> $capabilities  Optional. Associative array of capabilities to test against, i.e. `['<capability>' => true]`.
 	 * @return bool                               Whether the transport can be used.
+	 *
+	 * @codeCoverageIgnore  This is just a wrapper for a class that's only available in WordPress 6.2+ environments.
 	 */
 	public static function test( $capabilities = [] ) {
 
 		return class_exists( '\WpOrg\Requests\Transport\Curl' )
 			? \WpOrg\Requests\Transport\Curl::test( $capabilities )
 			: \Requests_Transport_cURL::test( $capabilities);
+	}
+
+	/**
+	 * Get the cURL handle for use in a multi-request
+	 *
+	 * @param  string       $url      URL to request.
+	 * @param  array        $headers  Associative array of request headers.
+	 * @param  string|array $data     Data to send either as the POST body, or as parameters in the URL for a GET/HEAD.
+	 * @param  array        $options  Request options, see {@see \WpOrg\Requests\Requests::response()} for documentation.
+	 *
+	 * @return resource|\CurlHandle  Subrequest's cURL handle.
+	 *
+	 * @codeCoverageIgnore  This is just a wrapper for a class that's only available in WordPress 6.2+ environments.
+	 */
+	public function &get_subrequest_handle( $url, $headers, $data, $options ) {
+		return $this->_curl->get_subrequest_handle( $url, $headers, $data, $options );
+	}
+
+	/**
+	 * Process a response
+	 *
+	 * @param  string $response  Response data from the body.
+	 * @param  array  $options   Request options.
+	 *
+	 * @return string|false  HTTP response data including headers. False if non-blocking.
+	 *
+	 * @throws \WpOrg\Requests\Exception
+	 *
+	 * @codeCoverageIgnore  This is just a wrapper for a class that's only available in WordPress 6.2+ environments.
+	 */
+	public function process_response( $response, $options ) {
+		return $this->_curl->process_response( $response, $options );
+	}
+
+	/**
+	 * Collect the headers as they are received
+	 *
+	 * @param  resource|\CurlHandle $handle   cURL handle.
+	 * @param  string               $headers  Header string.
+	 *
+	 * @return integer Length of provided header.
+	 *
+	 * @codeCoverageIgnore  This is just a wrapper for a class that's only available in WordPress 6.2+ environments.
+	 */
+	public function stream_headers( $handle, $headers ) {
+		return $this->_curl->stream_headers( $handle, $headers );
+	}
+
+	/**
+	 * Collect data as it's received
+	 *
+	 * @param resource|\CurlHandle  $handle  cURL handle.
+	 * @param string                $data    Body data.
+	 *
+	 * @return integer  Length of provided data.
+	 *
+	 * @codeCoverageIgnore  This is just a wrapper for a class that's only available in WordPress 6.2+ environments.
+	 */
+	public function stream_body( $handle, $data ) {
+		return $this->_curl->stream_body( $handle, $data );
 	}
 
 	/**

--- a/src/mocks/http.php
+++ b/src/mocks/http.php
@@ -44,7 +44,9 @@ class Http implements \PMC\Unit_Test\Interfaces\Mocker {
 	 * Constructor
 	 */
 	public function __construct() {
-		self::$_curl = new \WpOrg\Requests\Transport\Curl();
+		self::$_curl = class_exists( '\WpOrg\Requests\Transport\Curl' )
+			? new \WpOrg\Requests\Transport\Curl()
+			: new \Requests_Transport_cURL;
 	}
 
 	public function provide_service() {

--- a/src/mocks/http.php
+++ b/src/mocks/http.php
@@ -23,9 +23,9 @@ class Http implements \PMC\Unit_Test\Interfaces\Mocker {
 	/**
 	 * Curl request handler
 	 *
-	 * @var \WpOrg\Requests\Transport\Curl
+	 * @var \WpOrg\Requests\Transport\Curl|Requests_Transport_cURL
 	 */
-	protected static $_curl;
+	protected $_curl;
 
 	const FILTER_REMOTE_GET = 'pmc_mock_http_remote_get';
 	const MOCK_SERVICE      = 'http';
@@ -42,9 +42,13 @@ class Http implements \PMC\Unit_Test\Interfaces\Mocker {
 
 	/**
 	 * Constructor
+	 *
+	 * @codeCoverageIgnore  We can't emulate both WordPress < 6.2 and 6.2+ test environments at the same time.
 	 */
 	public function __construct() {
-		self::$_curl = new \WpOrg\Requests\Transport\Curl();
+		$this->_curl = class_exists( '\WpOrg\Requests\Transport\Curl' )
+			? new \WpOrg\Requests\Transport\Curl()
+			: new Requests_Transport_cURL();
 	}
 
 	public function provide_service() {

--- a/src/mocks/http.php
+++ b/src/mocks/http.php
@@ -44,9 +44,7 @@ class Http implements \PMC\Unit_Test\Interfaces\Mocker {
 	 * Constructor
 	 */
 	public function __construct() {
-		self::$_curl = class_exists( '\WpOrg\Requests\Transport\Curl' )
-			? new \WpOrg\Requests\Transport\Curl()
-			: new \Requests_Transport_cURL;
+		self::$_curl = new \WpOrg\Requests\Transport\Curl();
 	}
 
 	public function provide_service() {

--- a/src/mocks/http.php
+++ b/src/mocks/http.php
@@ -214,11 +214,11 @@ class Http implements \PMC\Unit_Test\Interfaces\Mocker {
 	 *
 	 * @see Requests_Transport_cURL::request() for details
 	 *
-	 * @param  string       $url      URL to request
-	 * @param  array        $headers  Associative array of request headers
-	 * @param  string|array $data     Data to send either as the POST body, or as parameters in the URL for a GET/HEAD
-	 * @param  array        $options  Request options, see {@see Requests::response()} for documentation
-	 * @return string                 Raw HTTP result
+	 * @param  string       $url      URL to request.
+	 * @param  array        $headers  Associative array of request headers.
+	 * @param  string|array $data     Data to send either as the POST body, or as parameters in the URL for a GET/HEAD.
+	 * @param  array        $options  Request options, see {@see Requests::response()} for documentation.
+	 * @return string                 Raw HTTP result.
 	 */
 	public function request( $url, $headers = [], $data = [], $options = [] ) {
 

--- a/src/mocks/http.php
+++ b/src/mocks/http.php
@@ -337,7 +337,10 @@ class Http implements \PMC\Unit_Test\Interfaces\Mocker {
 	 * @return bool                               Whether the transport can be used.
 	 */
 	public static function test( $capabilities = [] ) {
-		return self::$_curl::test( $capabilities );
+
+		return class_exists( '\WpOrg\Requests\Transport\Curl' )
+			? \WpOrg\Requests\Transport\Curl::test( $capabilities )
+			: \Requests_Transport_cURL::test( $capabilities);
 	}
 
 	/**

--- a/src/mocks/http.php
+++ b/src/mocks/http.php
@@ -214,11 +214,11 @@ class Http implements \PMC\Unit_Test\Interfaces\Mocker {
 	 *
 	 * @see Requests_Transport_cURL::request() for details
 	 *
-	 * @param string $url URL to request
-	 * @param array $headers Associative array of request headers
-	 * @param string|array $data Data to send either as the POST body, or as parameters in the URL for a GET/HEAD
-	 * @param array $options Request options, see {@see Requests::response()} for documentation
-	 * @return string Raw HTTP result
+	 * @param  string       $url      URL to request
+	 * @param  array        $headers  Associative array of request headers
+	 * @param  string|array $data     Data to send either as the POST body, or as parameters in the URL for a GET/HEAD
+	 * @param  array        $options  Request options, see {@see Requests::response()} for documentation
+	 * @return string                 Raw HTTP result
 	 */
 	public function request( $url, $headers = [], $data = [], $options = [] ) {
 

--- a/src/traits/base.php
+++ b/src/traits/base.php
@@ -28,6 +28,13 @@ use PMC\Unit_Test\Object_Cache;
 trait Base {
 
 	/**
+	 * Mock
+	 *
+	 * @var \PMC\Unit_Test\Mocks\Factory
+	 */
+	public $mock;
+
+	/**
 	 * @var array Default vars in class being tested
 	 */
 	protected $_default_vars = [];

--- a/src/traits/base.php
+++ b/src/traits/base.php
@@ -166,11 +166,8 @@ trait Base {
 
 		wp_cache_flush();
 
-		// WP 5.5 ready
-		if ( substr( getenv( 'WP_VERSION' ), 0, 3 ) >= '5.5' ) {
-			if ( is_object( $GLOBALS['wp_rewrite'] ) && ! $GLOBALS['wp_rewrite']->using_permalinks() ) {
-				$GLOBALS['wp_rewrite']->set_permalink_structure( '/%year%/%monthnum%/%category%/%postname%-%post_id%/' );
-			}
+		if ( is_object( $GLOBALS['wp_rewrite'] ) && ! $GLOBALS['wp_rewrite']->using_permalinks() ) {
+			$GLOBALS['wp_rewrite']->set_permalink_structure( '/%year%/%monthnum%/%category%/%postname%-%post_id%/' );
 		}
 
 		Utility::unset_singleton( \PMC\EComm\Tracking::class );

--- a/src/traits/base.php
+++ b/src/traits/base.php
@@ -474,24 +474,46 @@ trait Base {
 	}
 
 	/**
-	 * Overload function to allow manual bypass deprecated errors
+	 * Overload function to allow manual bypass deprecated errors\
+	 *
 	 * @codeCoverageIgnore Don't have a good way to trigger the code coverage at the moment
 	 */
 	public function expectedDeprecated() {  // phpcs:ignore
 		$caught_deprecated = [];
-		foreach ( $this->caught_deprecated as $caught ) {
-			$caught = apply_filters( 'pmc_deprecated_function', $caught );
+		foreach ( $this->caught_deprecated as $caught => $description ) {
+			if ( is_numeric( $caught ) ) {
+				$caught      = $description;
+				$description = false;
+			}
+			$caught = apply_filters( 'pmc_deprecated_function', $caught, $description );
 			if ( ! empty( $caught ) ) {
-				$caught_deprecated[] = $caught;
+				if ( $description === false ) {
+					/* WP 6.0 */
+					$caught_deprecated[] = $caught;
+				}
+				else {
+					/* WP 6.1 */
+					$caught_deprecated[$caught] = $description;
+				}
 			}
 		}
 		$this->caught_deprecated = $caught_deprecated;
-
 		$caught_doing_it_wrong = [];
-		foreach ( $this->caught_doing_it_wrong as $caught ) {
-			$caught = apply_filters( 'pmc_doing_it_wrong', $caught );
+		foreach ( $this->caught_doing_it_wrong as $caught => $description ) {
+			if ( is_numeric( $caught ) ) {
+				$caught      = $description;
+				$description = false;
+			}
+			$caught = apply_filters( 'pmc_doing_it_wrong', $caught, $description );
 			if ( ! empty( $caught ) ) {
-				$caught_doing_it_wrong[] = $caught;
+				if ( $description === false ) {
+					/* WP 6.0 */
+					$caught_doing_it_wrong[] = $caught;
+				}
+				else {
+					/* WP 6.1 */
+					$caught_doing_it_wrong[$caught] = $description;
+				}
 			}
 		}
 		$this->caught_doing_it_wrong = $caught_doing_it_wrong;

--- a/tests/test-mock-http.php
+++ b/tests/test-mock-http.php
@@ -24,9 +24,11 @@ class Mock_Requests extends Base {
 		$mock = $this->mock->http();
 
 		$this->assertInstanceOf(
-			'WpOrg\Requests\Transport\Curl',
+			class_exists( '\WpOrg\Requests\Transport\Curl' )
+				? 'WpOrg\Requests\Transport\Curl'
+				: '\Requests_Transport_cURL',
 			Utility::get_hidden_property( $mock, '_curl' ),
-			'WpOrg\Requets\Transport\Curl handler not set.'
+			'cURL handler not set.'
 		);
 	}
 

--- a/tests/test-mock-http.php
+++ b/tests/test-mock-http.php
@@ -44,7 +44,7 @@ class Mock_Requests extends Base {
 		$mocks = Utility::get_hidden_static_property( \PMC\Unit_Test\Mocks\Http::class, '_mock_match' );
 		$this->assertTrue( isset( $mocks['https://ifconfig.me/ip'] ) );
 
-		$result = \Requests::get( 'https://ifconfig.me/ip');
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/ip');
 		$this->assertTrue( $result->success );
 		$this->assertEquals( '[mock result]', $result->body );
 
@@ -59,7 +59,7 @@ class Mock_Requests extends Base {
 				'body' => 'body',
 			] );
 
-		$result = \Requests::get( 'https://ifconfig.me/ip');
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/ip');
 
 		$this->assertTrue( $result->success );
 		$this->assertEquals( 'body', $result->body );
@@ -69,7 +69,7 @@ class Mock_Requests extends Base {
 		$this->mock->http()->remove( 'https://ifconfig.me/ip' );
 
 		try {
-			$result = \Requests::get('https://ifconfig.me/ip');
+			$result = \WpOrg\Requests\Requests::get('https://ifconfig.me/ip');
 
 			// Condition test, in case where ifconfig.co service isn't responding
 			if ($result->success) {
@@ -92,7 +92,7 @@ class Mock_Requests extends Base {
 				},
 			] );
 
-		$result = \Requests::get( 'https://ifconfig.me/ip');
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/ip');
 		$this->assertTrue( $result->success );
 		$this->assertEquals( 'function body', $result->body );
 		$this->assertEquals( 'header', $result->headers['function']);
@@ -101,7 +101,7 @@ class Mock_Requests extends Base {
 				'body' => [ 'json' => 'result'],
 			] );
 
-		$result = \Requests::get( 'https://ifconfig.me/ip' );
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/ip' );
 		$this->assertTrue( $result->success );
 		$this->assertEquals( '{"json":"result"}', $result->body );
 
@@ -109,14 +109,14 @@ class Mock_Requests extends Base {
 				'file' => __DIR__ . '/mocks/mock-test/default.json',
 			] );
 
-		$result = \Requests::get( 'https://ifconfig.me/ip' );
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/ip' );
 		$this->assertTrue( $result->success );
 		$this->assertEquals( file_get_contents( __DIR__ . '/mocks/mock-test/default.json' ), $result->body );
 
 		$this->mock->http( 'https://ifconfig.me/ip', [
 				'raw' => __DIR__ . '/mocks/mock-test/http-raw.txt',
 			] );
-		$result = \Requests::get( 'https://ifconfig.me/ip' );
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/ip' );
 		$this->assertTrue( $result->success );
 		$this->assertEquals( 'This is a raw file http response mock', $result->body );
 
@@ -125,7 +125,7 @@ class Mock_Requests extends Base {
 					return [ 'data' => $data, 'headers' => $headers ];
 				},
 			] );
-		$result = \Requests::post( 'https://ifconfig.me/ip', [ 'header' => 'value' ], [ 'name' => 'pair' ] );
+		$result = \WpOrg\Requests\Requests::post( 'https://ifconfig.me/ip', [ 'header' => 'value' ], [ 'name' => 'pair' ] );
 		$this->assertTrue( $result->success );
 		$this->assertEquals( '{"data":{"name":"pair"},"headers":{"header":"value"}}', $result->body );
 
@@ -136,7 +136,7 @@ class Mock_Requests extends Base {
 			] );
 
 		try {
-			$result = \Requests::get( 'https://ifconfig.me/ip' );
+			$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/ip' );
 			$this->assertTrue( $result->success );
 			$this->assertNotEmpty( $result->body );
 			$this->assertMatchesRegularExpression( '/\d+\.\d+\.\d+\.\d+/', $result->body );
@@ -149,7 +149,7 @@ class Mock_Requests extends Base {
 		$this->assertTrue( isset( $mocks['*'] ) );
 
 		try {
-			$result = \Requests::get('https://ifconfig.me/ip');
+			$result = \WpOrg\Requests\Requests::get('https://ifconfig.me/ip');
 			$this->assertTrue($result->success);
 			$this->assertNotEmpty($result->body);
 			$this->assertMatchesRegularExpression('/\d+\.\d+\.\d+\.\d+/', $result->body);
@@ -157,18 +157,18 @@ class Mock_Requests extends Base {
 		catch(\Requests_Exception $ex) {
 		}
 
-		$result = \Requests::get( 'https://ifconfig.me/test' );
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/test' );
 		$this->assertTrue( $result->success );
 		$this->assertStringContainsString( 'intercept all traffics', $result->body );
 
 		$this->mock->http->once( 'https://ifconfig.me/once', 'once' );
 		$mocks = Utility::get_hidden_static_property( \PMC\Unit_Test\Mocks\Http::class, '_mock_match' );
 		$this->assertTrue( isset( $mocks['https://ifconfig.me/once'] ) );
-		$result = \Requests::get( 'https://ifconfig.me/once' );
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/once' );
 		$this->assertTrue( $result->success );
 		$this->assertStringContainsString( 'once', $result->body );
 
-		$result = \Requests::get( 'https://ifconfig.me/once' );
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/once' );
 		$this->assertTrue( $result->success );
 		$this->assertStringContainsString( 'intercept all traffics', $result->body );
 
@@ -180,18 +180,18 @@ class Mock_Requests extends Base {
 		$mocks = Utility::get_hidden_static_property( \PMC\Unit_Test\Mocks\Http::class, '_mock_next_match' );
 		$this->assertTrue( isset( $mocks['https://ifconfig.me/next'] ) );
 
-		$result = \Requests::get( 'https://ifconfig.me/next' );
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/next' );
 		$this->assertTrue( $result->success );
 		$this->assertStringContainsString( 'next', $result->body );
 
-		$result = \Requests::get( 'https://ifconfig.me/next' );
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/next' );
 		$this->assertTrue( $result->success );
 		$this->assertStringContainsString( 'once', $result->body );
 
 		$this->mock->http->next( '*', 'next' );
 		$mocks = Utility::get_hidden_static_property( \PMC\Unit_Test\Mocks\Http::class, '_mock_next_queues' );
 		$this->assertTrue( 1 === count( $mocks )  );
-		$result = \Requests::get( 'https://ifconfig.me/test' );
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/test' );
 		$this->assertTrue( $result->success );
 		$this->assertStringContainsString( 'next', $result->body );
 		$mocks = Utility::get_hidden_static_property( \PMC\Unit_Test\Mocks\Http::class, '_mock_next_queues' );
@@ -200,7 +200,7 @@ class Mock_Requests extends Base {
 		$this->mock->http->once( '*', [ 'raw' => "HTTP/1.1 200 OK\r\n\r\nonce" ] );
 		$mocks = Utility::get_hidden_static_property( \PMC\Unit_Test\Mocks\Http::class, '_mock_match' );
 		$this->assertTrue( isset( $mocks['*'] ) );
-		$result = \Requests::get( 'https://ifconfig.me/test' );
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/test' );
 		$this->assertTrue( $result->success );
 		$this->assertStringContainsString( 'once', $result->body );
 		$mocks = Utility::get_hidden_static_property( \PMC\Unit_Test\Mocks\Http::class, '_mock_match' );
@@ -219,7 +219,7 @@ class Mock_Requests extends Base {
 		$this->assertEmpty( Utility::get_hidden_static_property( \PMC\Unit_Test\Mocks\Http::class, '_mock_next_queues' ) );
 
 		try {
-			$result = \Requests::get('https://ifconfig.me/ip');
+			$result = \WpOrg\Requests\Requests::get('https://ifconfig.me/ip');
 			$this->assertTrue($result->success);
 			$this->assertNotEmpty($result->body);
 			$this->assertMatchesRegularExpression('/\d+\.\d+\.\d+\.\d+/', $result->body);
@@ -229,7 +229,7 @@ class Mock_Requests extends Base {
 
 
 		$this->mock->http->next( '*', 'test' );
-		$result = \Requests::get( 'https://ifconfig.me/ip' );
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/ip' );
 		$this->assertTrue( $result->success );
 		$this->assertStringContainsString( 'test', $result->body );
 		$this->assertEmpty( Utility::get_hidden_static_property( \PMC\Unit_Test\Mocks\Http::class, '_mock_next_queues' ) );
@@ -238,7 +238,7 @@ class Mock_Requests extends Base {
 		$this->mock->http()->reset()
 			->default_not_found( true, true );
 
-		$result = \Requests::get( 'https://ifconfig.me/ip' );
+		$result = \WpOrg\Requests\Requests::get( 'https://ifconfig.me/ip' );
 
 		$this->assertFalse( $result->success );
 		$this->assertEquals( 404, $result->status_code );

--- a/tests/test-mock-http.php
+++ b/tests/test-mock-http.php
@@ -12,8 +12,23 @@ use PMC\Unit_Test\Utility;
  * All test extends the base test abstract class.
  *
  * Class Mock_Requests.
+ *
+ * @coversDefaultClass \PMC\Unit_Test\Mocks\Http
  */
 class Mock_Requests extends Base {
+
+	/**
+	 * @covers ::__construct()
+	 */
+	public function test__construct() {
+		$this->mock->http();
+
+		$this->assertInstanceOf(
+			'WpOrg\Requests\Transport\Curl',
+			Utility::get_hidden_static_property( '\PMC\Unit_Test\Mocks\Http', '_curl' ),
+			'WpOrg\Requets\Transport\Curl handler not set.'
+		);
+	}
 
 	public function test_mock_requests() {
 

--- a/tests/test-mock-http.php
+++ b/tests/test-mock-http.php
@@ -21,11 +21,11 @@ class Mock_Requests extends Base {
 	 * @covers ::__construct()
 	 */
 	public function test__construct() {
-		$this->mock->http();
+		$mock = $this->mock->http();
 
 		$this->assertInstanceOf(
 			'WpOrg\Requests\Transport\Curl',
-			Utility::get_hidden_static_property( '\PMC\Unit_Test\Mocks\Http', '_curl' ),
+			Utility::get_hidden_property( $mock, '_curl' ),
 			'WpOrg\Requets\Transport\Curl handler not set.'
 		);
 	}


### PR DESCRIPTION
for [PASE-1455](https://penskemedia.atlassian.net/browse/PASE-1455)

The `Http` mock is currently extending `\Requests_Transport_cURL` (which was deprecated and mapped to `\WpOrg\Requests\Transport\Curl`), a `final` class [in WordPress 6.2](https://core.trac.wordpress.org/ticket/54504). This removes that extension and creates a local prop with the instance of  `\WpOrg\Requests\Transport\Curl` that methods/props can be used with.

This change has been tested with unit tests for the following in `pmc-plugins`:

1. `pmc-unit-test-example`
1. `pmc-admantx`
1. `pmc-footer`
1. `pmc-store-products`
1. `pmc-trackonomics`
1. `pmc-facebook-instant-articles`