### PR TITLE
Remove twentytwentyfive action in setUpBeforeClass.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "pmc/unit-test",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "PMC Unit Test",
   "authors": [
   ],

--- a/src/traits/base.php
+++ b/src/traits/base.php
@@ -136,6 +136,15 @@ trait Base {
 	}
 
 	/**
+	 * Things needed to run before the test class performs tests.
+	 *
+	 * @return void
+	 */
+	public function setUpBeforeClass(): void { // phpcs:ignore
+		remove_action( 'init', 'twentytwentyfive_register_block_bindings' );
+	}
+
+	/**
 	 * Override default setup function to speed up testing
 	 */
 	public function setUp() : void { // phpcs:ignore

--- a/src/traits/base.php
+++ b/src/traits/base.php
@@ -140,7 +140,8 @@ trait Base {
 	 *
 	 * @return void
 	 */
-	public function setUpBeforeClass(): void { // phpcs:ignore
+	public function setUpBeforeClass(): void {
+		parent::setupBeforeClass();
 		remove_action( 'init', 'twentytwentyfive_register_block_bindings' );
 	}
 


### PR DESCRIPTION
Unit tests are failing due to an action set by the twentytwentyfive theme. 

```
Unexpected incorrect usage notice for WP_Block_Bindings_Registry::register.
Block bindings source "twentytwentyfive/format" already registered. (This message was added in version 6.5.0.)
```